### PR TITLE
Feature/create search result function

### DIFF
--- a/src/app/Http/Controllers/EngineerSearchController.php
+++ b/src/app/Http/Controllers/EngineerSearchController.php
@@ -11,10 +11,13 @@ class EngineerSearchController extends Controller
     /**
      * エンジニア検索フォームを表示します。
      */
-    public function showSearchForm()
+    public function showSearchForm(Request $request) // Request を受け取るように変更
     {
-        $skills = Skill::orderBy('type')->orderBy('name')->get(); // スキル種別と名前でソート
-        return view('engineers.search_form', compact('skills'));
+        $skills = Skill::orderBy('type')->orderBy('name')->get();
+        return view('engineers.search_form', [
+            'availableSkills' => $skills,
+            'currentInputs' => $request->all() // 現在のリクエストパラメータを渡す
+        ]);
     }
 
     /**
@@ -24,12 +27,10 @@ class EngineerSearchController extends Controller
     {
         $query = Engineer::query()->with(['skills', 'projectExperiences']);
 
-        // --- 検索条件の受付 ---
         $searchKeyword = $request->input('keyword');
         $selectedSkillIds = $request->input('skills', []);
         $experienceYearsMin = $request->input('experience_years_min');
 
-        // キーワード検索 (氏名、自己PR、プロジェクト概要など)
         if (!empty($searchKeyword)) {
             $query->where(function ($q) use ($searchKeyword) {
                 $q->where('name', 'LIKE', "%{$searchKeyword}%")
@@ -42,36 +43,24 @@ class EngineerSearchController extends Controller
             });
         }
 
-        // スキルによる絞り込み (複数選択)
-        if (!empty($selectedSkillIds)) {
-            // 選択された全てのスキルIDを持つエンジニアを検索
-            // (リレーション先のスキルIDが、選択されたスキルIDの配列に全て含まれる、という意味ではないので注意)
-            // 選択されたスキルIDのいずれかを持つエンジニアを検索する場合はwhereInで良い
-            // ここでは、選択されたスキルIDをAND条件のように扱う (全て持つエンジニアを探す場合)
-            // $query->whereHas('skills', function ($q) use ($selectedSkillIds) {
-            //     $q->whereIn('skills.id', $selectedSkillIds);
-            // }, '=', count($selectedSkillIds));
-            //
-            // OR条件（いずれかのスキルを持つ）で絞り込む場合：
+        if (!empty($selectedSkillIds) && is_array($selectedSkillIds)) { // 配列であることも確認
             $query->whereHas('skills', function ($q) use ($selectedSkillIds) {
                  $q->whereIn('skills.id', $selectedSkillIds);
             });
         }
 
-        // 経験年数による絞り込み (総実務経験年数)
         if (!empty($experienceYearsMin)) {
             $query->where('total_experience_years', '>=', $experienceYearsMin);
         }
 
-        $engineers = $query->orderBy('name')->paginate(10); // 氏名でソート、10件ずつページネーション
-
-        // 検索フォーム表示用に再度スキル一覧を取得
+        $engineers = $query->orderBy('name')->paginate(10);
         $skillsForForm = Skill::orderBy('type')->orderBy('name')->get();
 
         return view('engineers.search_results', [
             'engineers' => $engineers,
-            'skillsForForm' => $skillsForForm,
-            'request' => $request, // 検索条件をビューに渡してフォームに再表示
+            'availableSkills' => $skillsForForm,
+            'currentInputs' => $request->all(),
+            'request' => $request,
         ]);
     }
 }

--- a/src/app/Http/Controllers/EngineerSearchController.php
+++ b/src/app/Http/Controllers/EngineerSearchController.php
@@ -17,4 +17,61 @@ class EngineerSearchController extends Controller
         return view('engineers.search_form', compact('skills'));
     }
 
+    /**
+     * エンジニアを検索し、結果を表示します。
+     */
+    public function searchEngineers(Request $request)
+    {
+        $query = Engineer::query()->with(['skills', 'projectExperiences']);
+
+        // --- 検索条件の受付 ---
+        $searchKeyword = $request->input('keyword');
+        $selectedSkillIds = $request->input('skills', []);
+        $experienceYearsMin = $request->input('experience_years_min');
+
+        // キーワード検索 (氏名、自己PR、プロジェクト概要など)
+        if (!empty($searchKeyword)) {
+            $query->where(function ($q) use ($searchKeyword) {
+                $q->where('name', 'LIKE', "%{$searchKeyword}%")
+                  ->orWhere('self_pr', 'LIKE', "%{$searchKeyword}%")
+                  ->orWhereHas('projectExperiences', function ($subQ) use ($searchKeyword) {
+                      $subQ->where('project_name', 'LIKE', "%{$searchKeyword}%")
+                           ->orWhere('project_summary', 'LIKE', "%{$searchKeyword}%")
+                           ->orWhere('tools_technologies_used', 'LIKE', "%{$searchKeyword}%");
+                  });
+            });
+        }
+
+        // スキルによる絞り込み (複数選択)
+        if (!empty($selectedSkillIds)) {
+            // 選択された全てのスキルIDを持つエンジニアを検索
+            // (リレーション先のスキルIDが、選択されたスキルIDの配列に全て含まれる、という意味ではないので注意)
+            // 選択されたスキルIDのいずれかを持つエンジニアを検索する場合はwhereInで良い
+            // ここでは、選択されたスキルIDをAND条件のように扱う (全て持つエンジニアを探す場合)
+            // $query->whereHas('skills', function ($q) use ($selectedSkillIds) {
+            //     $q->whereIn('skills.id', $selectedSkillIds);
+            // }, '=', count($selectedSkillIds));
+            //
+            // OR条件（いずれかのスキルを持つ）で絞り込む場合：
+            $query->whereHas('skills', function ($q) use ($selectedSkillIds) {
+                 $q->whereIn('skills.id', $selectedSkillIds);
+            });
+        }
+
+        // 経験年数による絞り込み (総実務経験年数)
+        if (!empty($experienceYearsMin)) {
+            $query->where('total_experience_years', '>=', $experienceYearsMin);
+        }
+
+        $engineers = $query->orderBy('name')->paginate(10); // 氏名でソート、10件ずつページネーション
+
+        // 検索フォーム表示用に再度スキル一覧を取得
+        $skillsForForm = Skill::orderBy('type')->orderBy('name')->get();
+
+        return view('engineers.search_results', [
+            'engineers' => $engineers,
+            'skillsForForm' => $skillsForForm,
+            'request' => $request, // 検索条件をビューに渡してフォームに再表示
+        ]);
+    }
 }

--- a/src/app/Providers/AppServiceProvider.php
+++ b/src/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Pagination\Paginator;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -19,6 +20,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Paginator::useBootstrapFive();
     }
 }

--- a/src/resources/views/engineers/partials/_search_form_fields.blade.php
+++ b/src/resources/views/engineers/partials/_search_form_fields.blade.php
@@ -1,0 +1,39 @@
+{{-- resources/views/engineers/partials/_search_form_fields.blade.php --}}
+
+{{-- キーワード検索 --}}
+<div class="mb-3">
+    <label for="keyword" class="form-label">キーワード</label>
+    <input type="text" class="form-control" id="keyword" name="keyword" value="{{ $currentInputs['keyword'] ?? old('keyword', '') }}" placeholder="氏名、スキル、プロジェクト概要など">
+</div>
+
+{{-- スキル検索 (複数選択チェックボックス) --}}
+<div class="mb-3">
+    <label class="form-label">スキル</label>
+    <div class="row">
+        @php
+            $skillTypes = $availableSkills->groupBy('type');
+            $selectedSkills = $currentInputs['skills'] ?? old('skills', []);
+            if (!is_array($selectedSkills)) $selectedSkills = []; // 配列であることを保証
+        @endphp
+        @foreach($skillTypes as $type => $skillsOfType)
+        <div class="col-md-3 mb-2">
+            <strong>{{ ucfirst(str_replace('_', ' ', $type)) }}</strong>
+            @foreach($skillsOfType as $skill)
+            <div class="form-check">
+                <input class="form-check-input" type="checkbox" name="skills[]" value="{{ $skill->id }}" id="skill_partial_{{ $skill->id }}"
+                    {{ in_array($skill->id, $selectedSkills) ? 'checked' : '' }}>
+                <label class="form-check-label" for="skill_partial_{{ $skill->id }}">
+                    {{ $skill->name }}
+                </label>
+            </div>
+            @endforeach
+        </div>
+        @endforeach
+    </div>
+</div>
+
+{{-- 経験年数 (下限) --}}
+<div class="mb-3">
+    <label for="experience_years_min" class="form-label">総実務経験年数 (下限)</label>
+    <input type="number" class="form-control" id="experience_years_min" name="experience_years_min" value="{{ $currentInputs['experience_years_min'] ?? old('experience_years_min', '') }}" min="0" placeholder="例: 3 (年以上)">
+</div>

--- a/src/resources/views/engineers/search_form.blade.php
+++ b/src/resources/views/engineers/search_form.blade.php
@@ -12,41 +12,11 @@
                 </div>
                 <div class="card-body">
                     <form action="{{ route('engineers.show') }}" method="GET">
-                        {{-- キーワード検索 --}}
-                        <div class="mb-3">
-                            <label for="keyword" class="form-label">キーワード</label>
-                            <input type="text" class="form-control" id="keyword" name="keyword" value="{{ request('keyword') }}" placeholder="氏名、スキル、プロジェクト概要など">
-                        </div>
-
-                        {{-- スキル検索 (複数選択チェックボックス) --}}
-                        <div class="mb-3">
-                            <label class="form-label">スキル</label>
-                            <div class="row">
-                                @php $skillTypes = $skills->groupBy('type'); @endphp
-                                @foreach($skillTypes as $type => $skillsOfType)
-                                <div class="col-md-3 mb-2">
-                                    <strong>{{ ucfirst(str_replace('_', ' ', $type)) }}</strong>
-                                    @foreach($skillsOfType as $skill)
-                                    <div class="form-check">
-                                        <input class="form-check-input" type="checkbox" name="skills[]" value="{{ $skill->id }}" id="skill_{{ $skill->id }}"
-                                            {{ (is_array(request('skills')) && in_array($skill->id, request('skills'))) ? 'checked' : '' }}>
-                                        <label class="form-check-label" for="skill_{{ $skill->id }}">
-                                            {{ $skill->name }}
-                                        </label>
-                                    </div>
-                                    @endforeach
-                                </div>
-                                @endforeach
-                            </div>
-                        </div>
-
-                        {{-- 経験年数 (下限) --}}
-                        <div class="mb-3">
-                            <label for="experience_years_min" class="form-label">総実務経験年数 (下限)</label>
-                            <input type="number" class="form-control" id="experience_years_min" name="experience_years_min" value="{{ request('experience_years_min') }}" min="0" placeholder="例: 3 (年以上)">
-                        </div>
+                        {{-- 共通フォーム部分をインクルード --}}
+                        @include('engineers.partials._search_form_fields', ['availableSkills' => $availableSkills, 'currentInputs' => $currentInputs])
 
                         <button type="submit" class="btn btn-primary">検索する</button>
+                        {{-- リセットは検索フォーム表示用ルートへ --}}
                         <a href="{{ route('engineers.searchForm') }}" class="btn btn-secondary">リセット</a>
                     </form>
                 </div>

--- a/src/resources/views/engineers/search_results.blade.php
+++ b/src/resources/views/engineers/search_results.blade.php
@@ -1,0 +1,108 @@
+@extends('layouts.app')
+
+@section('title', 'エンジニア検索結果')
+
+@section('content')
+<div class="container mt-4">
+    <div class="row mb-4">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-header">
+                    <h4>エンジニア再検索</h4>
+                </div>
+                <div class="card-body">
+                    <form action="{{ route('engineers.show') }}" method="GET">
+                        <div class="mb-3">
+                            <label for="keyword" class="form-label">キーワード</label>
+                            <input type="text" class="form-control" id="keyword" name="keyword" value="{{ $request->input('keyword') }}" placeholder="氏名、スキル、プロジェクト概要など">
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">スキル</label>
+                            <div class="row">
+                                @php $skillTypes = $skillsForForm->groupBy('type'); @endphp
+                                @foreach($skillTypes as $type => $skillsOfType)
+                                <div class="col-md-3 mb-2">
+                                    <strong>{{ ucfirst(str_replace('_', ' ', $type)) }}</strong>
+                                    @foreach($skillsOfType as $skill)
+                                    <div class="form-check">
+                                        <input class="form-check-input" type="checkbox" name="skills[]" value="{{ $skill->id }}" id="form_skill_{{ $skill->id }}"
+                                            {{ (is_array($request->input('skills')) && in_array($skill->id, $request->input('skills'))) ? 'checked' : '' }}>
+                                        <label class="form-check-label" for="form_skill_{{ $skill->id }}">
+                                            {{ $skill->name }}
+                                        </label>
+                                    </div>
+                                    @endforeach
+                                </div>
+                                @endforeach
+                            </div>
+                        </div>
+                        <div class="mb-3">
+                            <label for="experience_years_min" class="form-label">総実務経験年数 (下限)</label>
+                            <input type="number" class="form-control" id="experience_years_min" name="experience_years_min" value="{{ $request->input('experience_years_min') }}" min="0" placeholder="例: 3 (年以上)">
+                        </div>
+                        <button type="submit" class="btn btn-primary">再検索</button>
+                        <a href="{{ route('engineers.searchForm') }}" class="btn btn-secondary">条件クリア</a>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {{-- 検索結果 --}}
+    <div class="row">
+        <div class="col-md-12">
+            <div class="card">
+                <div class="card-header">
+                    <h4>検索結果 ({{ $engineers->total() }}件)</h4>
+                </div>
+                <div class="card-body">
+                    @if($engineers->count() > 0)
+                        <div class="table-responsive">
+                            <table class="table table-striped table-hover">
+                                <thead>
+                                    <tr>
+                                        <th>氏名</th>
+                                        <th>主要スキル</th>
+                                        <th>総実務経験年数</th>
+                                        <th>希望単価(下限)</th>
+                                        <th>稼働開始時期</th>
+                                        <th>自己PR (一部)</th>
+                                        {{-- <th>詳細</th> --}}
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach($engineers as $engineer)
+                                    <tr>
+                                        <td>{{ $engineer->name }}</td>
+                                        <td>
+                                            @foreach($engineer->skills->take(3) as $skill) {{-- 主要スキルを3つまで表示 --}}
+                                                <span class="badge bg-info text-dark me-1">{{ $skill->name }} ({{ $skill->pivot->experience_years ?? 'N/A' }}年)</span>
+                                            @endforeach
+                                            @if($engineer->skills->count() > 3)
+                                                <span class="badge bg-secondary text-white">他</span>
+                                            @endif
+                                        </td>
+                                        <td>{{ $engineer->total_experience_years ?? 'N/A' }} 年</td>
+                                        <td>{{ number_format($engineer->desired_salary_min) ?? 'N/A' }} 円</td>
+                                        <td>{{ $engineer->availability_start_date ? \Carbon\Carbon::parse($engineer->availability_start_date)->format('Y年m月d日') : 'N/A' }}</td>
+                                        <td>{{ Str::limit($engineer->self_pr, 50) }}</td> {{-- 自己PRを50文字まで表示 --}}
+                                        {{-- 詳細表示ページへのリンクは後ほど作成 --}}
+                                        {{-- <td><a href="#" class="btn btn-sm btn-outline-primary">詳細</a></td> --}}
+                                    </tr>
+                                    @endforeach
+                                </tbody>
+                            </table>
+                        </div>
+                        {{-- ページネーションリンク --}}
+                        <div class="d-flex justify-content-center">
+                            {{ $engineers->appends($request->except('page'))->links() }}
+                        </div>
+                    @else
+                        <p class="text-center">該当するエンジニアは見つかりませんでした。</p>
+                    @endif
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/src/resources/views/engineers/search_results.blade.php
+++ b/src/resources/views/engineers/search_results.blade.php
@@ -4,51 +4,47 @@
 
 @section('content')
 <div class="container mt-4">
+    {{-- 検索オプション --}}
     <div class="row mb-4">
         <div class="col-md-12">
             <div class="card">
-                <div class="card-header">
-                    <h4>エンジニア再検索</h4>
-                </div>
-                <div class="card-body">
-                    <form action="{{ route('engineers.show') }}" method="GET">
-                        <div class="mb-3">
-                            <label for="keyword" class="form-label">キーワード</label>
-                            <input type="text" class="form-control" id="keyword" name="keyword" value="{{ $request->input('keyword') }}" placeholder="氏名、スキル、プロジェクト概要など">
-                        </div>
-                        <div class="mb-3">
-                            <label class="form-label">スキル</label>
-                            <div class="row">
-                                @php $skillTypes = $skillsForForm->groupBy('type'); @endphp
-                                @foreach($skillTypes as $type => $skillsOfType)
-                                <div class="col-md-3 mb-2">
-                                    <strong>{{ ucfirst(str_replace('_', ' ', $type)) }}</strong>
-                                    @foreach($skillsOfType as $skill)
-                                    <div class="form-check">
-                                        <input class="form-check-input" type="checkbox" name="skills[]" value="{{ $skill->id }}" id="form_skill_{{ $skill->id }}"
-                                            {{ (is_array($request->input('skills')) && in_array($skill->id, $request->input('skills'))) ? 'checked' : '' }}>
-                                        <label class="form-check-label" for="form_skill_{{ $skill->id }}">
-                                            {{ $skill->name }}
-                                        </label>
-                                    </div>
-                                    @endforeach
-                                </div>
-                                @endforeach
-                            </div>
-                        </div>
-                        <div class="mb-3">
-                            <label for="experience_years_min" class="form-label">総実務経験年数 (下限)</label>
-                            <input type="number" class="form-control" id="experience_years_min" name="experience_years_min" value="{{ $request->input('experience_years_min') }}" min="0" placeholder="例: 3 (年以上)">
-                        </div>
-                        <button type="submit" class="btn btn-primary">再検索</button>
-                        <a href="{{ route('engineers.searchForm') }}" class="btn btn-secondary">条件クリア</a>
-                    </form>
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <h4 class="mb-0">検索オプション</h4>
+                    <button class="btn btn-outline-primary" type="button" data-bs-toggle="modal" data-bs-target="#searchModal">
+                        {{-- ハンバーガーメニューアイコン --}}
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-list" viewBox="0 0 16 16">
+                            <path fill-rule="evenodd" d="M2.5 12a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5m0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5m0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5"/>
+                        </svg>
+                        検索条件を編集
+                    </button>
                 </div>
             </div>
         </div>
     </div>
 
-    {{-- 検索結果 --}}
+    {{-- 検索フォーム用モーダル --}}
+    <div class="modal fade" id="searchModal" tabindex="-1" aria-labelledby="searchModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <form action="{{ route(Route::currentRouteName() ?: 'engineers.search') }}" method="GET">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="searchModalLabel">検索条件</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        @include('engineers.partials._search_form_fields', ['availableSkills' => $availableSkills, 'currentInputs' => $currentInputs])
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">閉じる</button>
+                        <a href="{{ route('engineers.searchForm') }}" class="btn btn-outline-info">条件をリセットして新規検索</a>
+                        <button type="submit" class="btn btn-primary">この条件で再検索</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    {{-- 検索結果表示エリア --}}
     <div class="row">
         <div class="col-md-12">
             <div class="card">
@@ -67,7 +63,6 @@
                                         <th>希望単価(下限)</th>
                                         <th>稼働開始時期</th>
                                         <th>自己PR (一部)</th>
-                                        {{-- <th>詳細</th> --}}
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -75,7 +70,7 @@
                                     <tr>
                                         <td>{{ $engineer->name }}</td>
                                         <td>
-                                            @foreach($engineer->skills->take(3) as $skill) {{-- 主要スキルを3つまで表示 --}}
+                                            @foreach($engineer->skills->take(3) as $skill)
                                                 <span class="badge bg-info text-dark me-1">{{ $skill->name }} ({{ $skill->pivot->experience_years ?? 'N/A' }}年)</span>
                                             @endforeach
                                             @if($engineer->skills->count() > 3)
@@ -83,17 +78,14 @@
                                             @endif
                                         </td>
                                         <td>{{ $engineer->total_experience_years ?? 'N/A' }} 年</td>
-                                        <td>{{ number_format($engineer->desired_salary_min) ?? 'N/A' }} 円</td>
+                                        <td>{{ $engineer->desired_salary_min ? number_format($engineer->desired_salary_min) . ' 円' : 'N/A' }}</td>
                                         <td>{{ $engineer->availability_start_date ? \Carbon\Carbon::parse($engineer->availability_start_date)->format('Y年m月d日') : 'N/A' }}</td>
-                                        <td>{{ Str::limit($engineer->self_pr, 50) }}</td> {{-- 自己PRを50文字まで表示 --}}
-                                        {{-- 詳細表示ページへのリンクは後ほど作成 --}}
-                                        {{-- <td><a href="#" class="btn btn-sm btn-outline-primary">詳細</a></td> --}}
+                                        <td>{{ Str::limit($engineer->self_pr, 50) }}</td>
                                     </tr>
                                     @endforeach
                                 </tbody>
                             </table>
                         </div>
-                        {{-- ページネーションリンク --}}
                         <div class="d-flex justify-content-center">
                             {{ $engineers->appends($request->except('page'))->links() }}
                         </div>

--- a/src/resources/views/vendor/pagination/bootstrap-5.blade.php
+++ b/src/resources/views/vendor/pagination/bootstrap-5.blade.php
@@ -1,0 +1,88 @@
+@if ($paginator->hasPages())
+    <nav class="d-flex justify-items-center justify-content-between">
+        <div class="d-flex justify-content-between flex-fill d-sm-none">
+            <ul class="pagination">
+                {{-- Previous Page Link --}}
+                @if ($paginator->onFirstPage())
+                    <li class="page-item disabled" aria-disabled="true">
+                        <span class="page-link">@lang('pagination.previous')</span>
+                    </li>
+                @else
+                    <li class="page-item">
+                        <a class="page-link" href="{{ $paginator->previousPageUrl() }}" rel="prev">@lang('pagination.previous')</a>
+                    </li>
+                @endif
+
+                {{-- Next Page Link --}}
+                @if ($paginator->hasMorePages())
+                    <li class="page-item">
+                        <a class="page-link" href="{{ $paginator->nextPageUrl() }}" rel="next">@lang('pagination.next')</a>
+                    </li>
+                @else
+                    <li class="page-item disabled" aria-disabled="true">
+                        <span class="page-link">@lang('pagination.next')</span>
+                    </li>
+                @endif
+            </ul>
+        </div>
+
+        {{--  <div class="d-none flex-sm-fill d-sm-flex align-items-sm-center justify-content-sm-between">
+            <div>
+                <p class="small text-muted">
+                    {!! __('Showing') !!}
+                    <span class="fw-semibold">{{ $paginator->firstItem() }}</span>
+                    {!! __('to') !!}
+                    <span class="fw-semibold">{{ $paginator->lastItem() }}</span>
+                    {!! __('of') !!}
+                    <span class="fw-semibold">{{ $paginator->total() }}</span>
+                    {!! __('results') !!}
+                </p>
+            </div>  --}}
+
+            <div>
+                <ul class="pagination">
+                    {{-- Previous Page Link --}}
+                    @if ($paginator->onFirstPage())
+                        <li class="page-item disabled" aria-disabled="true" aria-label="@lang('pagination.previous')">
+                            <span class="page-link" aria-hidden="true">&lsaquo;</span>
+                        </li>
+                    @else
+                        <li class="page-item">
+                            <a class="page-link" href="{{ $paginator->previousPageUrl() }}" rel="prev" aria-label="@lang('pagination.previous')">&lsaquo;</a>
+                        </li>
+                    @endif
+
+                    {{-- Pagination Elements --}}
+                    @foreach ($elements as $element)
+                        {{-- "Three Dots" Separator --}}
+                        @if (is_string($element))
+                            <li class="page-item disabled" aria-disabled="true"><span class="page-link">{{ $element }}</span></li>
+                        @endif
+
+                        {{-- Array Of Links --}}
+                        @if (is_array($element))
+                            @foreach ($element as $page => $url)
+                                @if ($page == $paginator->currentPage())
+                                    <li class="page-item active" aria-current="page"><span class="page-link">{{ $page }}</span></li>
+                                @else
+                                    <li class="page-item"><a class="page-link" href="{{ $url }}">{{ $page }}</a></li>
+                                @endif
+                            @endforeach
+                        @endif
+                    @endforeach
+
+                    {{-- Next Page Link --}}
+                    @if ($paginator->hasMorePages())
+                        <li class="page-item">
+                            <a class="page-link" href="{{ $paginator->nextPageUrl() }}" rel="next" aria-label="@lang('pagination.next')">&rsaquo;</a>
+                        </li>
+                    @else
+                        <li class="page-item disabled" aria-disabled="true" aria-label="@lang('pagination.next')">
+                            <span class="page-link" aria-hidden="true">&rsaquo;</span>
+                        </li>
+                    @endif
+                </ul>
+            </div>
+        </div>
+    </nav>
+@endif

--- a/src/resources/views/vendor/pagination/simple-bootstrap-5.blade.php
+++ b/src/resources/views/vendor/pagination/simple-bootstrap-5.blade.php
@@ -1,0 +1,29 @@
+@if ($paginator->hasPages())
+    <nav role="navigation" aria-label="Pagination Navigation">
+        <ul class="pagination">
+            {{-- Previous Page Link --}}
+            @if ($paginator->onFirstPage())
+                <li class="page-item disabled" aria-disabled="true">
+                    <span class="page-link">{!! __('pagination.previous') !!}</span>
+                </li>
+            @else
+                <li class="page-item">
+                    <a class="page-link" href="{{ $paginator->previousPageUrl() }}" rel="prev">
+                        {!! __('pagination.previous') !!}
+                    </a>
+                </li>
+            @endif
+
+            {{-- Next Page Link --}}
+            @if ($paginator->hasMorePages())
+                <li class="page-item">
+                    <a class="page-link" href="{{ $paginator->nextPageUrl() }}" rel="next">{!! __('pagination.next') !!}</a>
+                </li>
+            @else
+                <li class="page-item disabled" aria-disabled="true">
+                    <span class="page-link">{!! __('pagination.next') !!}</span>
+                </li>
+            @endif
+        </ul>
+    </nav>
+@endif

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -17,3 +17,6 @@ Route::get('/hello', function () {
 
 // エンジニア検索フォーム表示
 Route::get('/engineers/search', [EngineerSearchController::class, 'showSearchForm'])->name('engineers.searchForm');
+
+// エンジニア検索実行と結果表示
+Route::get('/engineers/show', [EngineerSearchController::class, 'searchEngineers'])->name('engineers.show');


### PR DESCRIPTION
# エンジニア検索機能の実装とUI改善

## 概要 (Overview)

エンジニア情報を効率的に検索するための検索機能および関連画面を実装しました。
主な変更点として、検索結果表示画面の追加、検索オプションUIの改善（モーダル化）、ページネーションのBootstrap 5適用、検索フォームの共通コンポーネント化が含まれます。

## 対応内容 (Key Changes)

- **検索結果画面の追加・改修 (`search_results.blade.php`)**
    - 検索条件に合致したエンジニア情報をテーブル形式で表示するようにしました。
        - 表示項目: 氏名、主要スキル（経験年数含む）、総実務経験年数、希望単価(下限)、稼働開始時期、自己PR(一部)
    - 検索結果画面に「検索オプション」を設置しました。
    - 検索オプションのトリガーとしてハンバーガーメニュー風の「検索条件を編集」ボタンを配置し、クリックすると検索項目（キーワード、スキル、経験年数）がモーダル画面で表示されるようにUIを改善しました。モーダルからの再検索が可能です。

- **ページネーションのBootstrap 5適用**
    - `AppServiceProvider` にて `Paginator::useBootstrapFive()` を設定し、ページネーションの表示スタイルをBootstrap 5に統一しました。
    - 上記対応により、ページネーションのレイアウト崩れを修正し、不要な「Showing X to Y of Z results」といった文言を非表示にしました（ページネーションビューをカスタマイズして対応した場合）。

- **検索項目の共通化（Bladeパーシャル化）**
    - エンジニア検索画面 (`search_form.blade.php`) と検索結果画面の再検索モーダルで使用する検索フォームの入力フィールド群を、共通のBladeパーシャル (`engineers.partials._search_form_fields.blade.php`) に切り出しました。
    - これにより、コードの重複を削減し、保守性を向上させました。

## 確認手順 (How to Test)

1.  **検索機能の基本動作確認:**
    - キーワード、スキル（単数・複数）、総実務経験年数をそれぞれ単独、または組み合わせて検索を実行し、期待されるエンジニア情報がテーブル形式で表示されることを確認。
    - 該当するエンジニアがいない場合、「該当するエンジニアは見つかりませんでした。」と表示されることを確認してください。
2.  **検索結果画面のUI確認:**
    - 検索結果画面上部に「検索オプション」セクションがあり、「検索条件を編集」ボタン（ハンバーガーメニュー風アイコン付き）が表示されていることを確認。
    - 「検索条件を編集」ボタンをクリックすると、検索条件入力用のモーダルウィンドウが正しく表示され、現在の検索条件が引き継がれていることを確認。
    - モーダル内のフォームで条件を変更し、「この条件で再検索」ボタンを押下すると、モーダルが閉じて検索結果が更新されることを確認。
    - モーダル内の「条件をリセットして新規検索」ボタンで、初期の検索フォーム画面 (`/engineers/search`) に遷移することを確認。
3.  **ページネーションの動作・表示確認:**
    - 検索結果が複数ページにわたる場合、ページネーションリンクがBootstrap 5のスタイルで正しく表示されていることを確認。
    - ページネーションリンクをクリックし、ページが正しく遷移することを確認してください。
    - 不要な「Showing X to Y of Z results」といった文言が表示されていないことを確認。
4.  **検索項目の共通化確認:**
    - 初期検索画面と、検索結果画面のモーダル内再検索フォームの両方で、検索条件の入力と保持が正しく機能することを確認してください。

## その他 (Remarks)

- 検索条件の入力値に対するバリデーションは、今回の対応範囲外です。必要に応じて別途対応します。
- エンジニア詳細表示機能は今回のスコープ外となります。

レビューのほどよろしくお願いいたします。