### PR TITLE
エンジニア詳細画面の追加

### DIFF
--- a/src/app/Http/Controllers/EngineerSearchController.php
+++ b/src/app/Http/Controllers/EngineerSearchController.php
@@ -11,12 +11,12 @@ class EngineerSearchController extends Controller
     /**
      * エンジニア検索フォームを表示します。
      */
-    public function showSearchForm(Request $request) // Request を受け取るように変更
+    public function showSearchForm(Request $request)
     {
         $skills = Skill::orderBy('type')->orderBy('name')->get();
         return view('engineers.search_form', [
             'availableSkills' => $skills,
-            'currentInputs' => $request->all() // 現在のリクエストパラメータを渡す
+            'currentInputs' => $request->all()
         ]);
     }
 
@@ -43,7 +43,7 @@ class EngineerSearchController extends Controller
             });
         }
 
-        if (!empty($selectedSkillIds) && is_array($selectedSkillIds)) { // 配列であることも確認
+        if (!empty($selectedSkillIds) && is_array($selectedSkillIds)){
             $query->whereHas('skills', function ($q) use ($selectedSkillIds) {
                  $q->whereIn('skills.id', $selectedSkillIds);
             });
@@ -62,5 +62,25 @@ class EngineerSearchController extends Controller
             'currentInputs' => $request->all(),
             'request' => $request,
         ]);
+    }
+
+    /**
+     * 指定されたエンジニアの詳細情報を表示します。
+     *
+     * @param  \App\Models\Engineer  $engineer ルートモデルバインディングにより注入されるEngineerインスタンス
+     * @return \Illuminate\View\View
+     */
+    public function showDetail(Engineer $engineer)
+    {
+        // エンジニアに関連する全ての情報をEagerロードする
+        // (N+1問題を避けるため、ビューでアクセスするリレーションをここで読み込む)
+        $engineer->load([
+            'skills',
+            'projectExperiences',
+            'qualifications',
+            'languageSkills'
+        ]);
+
+        return view('engineers.detail', compact('engineer'));
     }
 }

--- a/src/app/Models/Engineer.php
+++ b/src/app/Models/Engineer.php
@@ -9,8 +9,9 @@ class Engineer extends Model
 {
     use HasFactory;
 
-    // created_at, updated_at 以外のカラムも必要に応じて $fillable や $guarded を設定
-
+    // ----------------------------------------------------------------------
+    // DB処理
+    // ----------------------------------------------------------------------
     public function skills()
     {
         // engineersテーブルとskillsテーブルを中間テーブルengineer_skillsを介して多対多の関係で結びつける
@@ -37,5 +38,83 @@ class Engineer extends Model
     {
         return $this->hasMany(LanguageSkill::class);
     }
-}
 
+    // ----------------------------------------------------------------------
+    // コンバート処理
+    // ----------------------------------------------------------------------
+    /**
+     * 年代の表示用文字列を取得します。
+     * 例: '30s_late' -> '30代後半'
+     *
+     * @return string
+     */
+    public function getDisplayAgeGroupAttribute(): string
+    {
+        if (empty($this->age_group)) {
+            return '未設定';
+        }
+
+        // データベースの値 (例: "30s_late") をアンダースコアで分割
+        $parts = explode('_', $this->age_group);
+
+        // "30s" と "late" のように2つの部分に分かれることを期待
+        if (count($parts) === 2) {
+            $decadeIdentifier = $parts[0]; // 例: "30s"
+            $suffixKey = $parts[1];        // 例: "late"
+
+            $decadeNumber = str_replace('s', '', $decadeIdentifier);
+
+            if (is_numeric($decadeNumber)) {
+                // config ファイルから接尾辞の表示文字列を取得
+                // config('display_mappings.age_group_suffix.late') のようになる
+                $suffixDisplay = config('display_mappings.age_group_suffix.' . $suffixKey);
+
+                // 接尾辞の表示文字列が見つかれば、結合して返す
+                if ($suffixDisplay) {
+                    return $decadeNumber . '代' . $suffixDisplay; // 例: "30" + "代" + "後半" -> "30代後半"
+                }
+            }
+        }
+
+        // 上記の処理でうまく変換できなかった場合は、元の値をそのまま返すか、
+        // より汎用的なフォールバック処理をここに追加することも可能です。
+        // 例: return $this->age_group; // 元の値 '30s_late' をそのまま返す
+        // ここでは、変換できなかった場合も元の値を返すようにしています。
+        // もしくは、元の値を少し整形して返すことも考えられます。
+        // 例えば、'30s late' のようにアンダースコアをスペースに置換するなど。
+        // return str_replace('_', ' ', $this->age_group);
+
+        // 今回は、変換できなかった場合は元の値を返すようにします。
+        return $this->age_group ?? '未設定';
+    }
+
+    /**
+     * 性別の表示用文字列を取得します。
+     *
+     * @return string
+     */
+    public function getDisplayGenderAttribute(): string
+    {
+        return config('display_mappings.gender.' . $this->gender, $this->gender ?? '未設定');
+    }
+
+    /**
+     * 単価タイプの表示用文字列を取得します。
+     *
+     * @return string
+     */
+    public function getDisplaySalaryTypeAttribute(): string
+    {
+        return config('display_mappings.salary_type.' . $this->salary_type, $this->salary_type ?? 'N/A');
+    }
+
+    /**
+     * 稼働率の表示用文字列を取得します。
+     *
+     * @return string
+     */
+    public function getDisplayWorkCommitmentRateAttribute(): string
+    {
+        return config('display_mappings.work_commitment_rate.' . $this->work_commitment_rate, $this->work_commitment_rate ?? '未設定');
+    }
+}

--- a/src/config/display_mappings.php
+++ b/src/config/display_mappings.php
@@ -1,0 +1,30 @@
+<?php
+
+return [
+    'age_group_suffix' => [
+        'early' => '前半',
+        'mid'   => '半ば',
+        'late'  => '後半',
+    ],
+
+    'gender' => [
+        'male'   => '男性',
+        'female' => '女性',
+        'other'  => 'その他',
+    ],
+
+    'salary_type' => [
+        'monthly' => '月収',
+        'hourly'  => '時給',
+        'annual'  => '年収',
+    ],
+
+    'work_commitment_rate' => [
+        'full_time'    => 'フルタイム',
+        '5_days_week'  => '週5日',
+        '4_days_week'  => '週4日',
+        '3_days_week'  => '週3日',
+        '2_days_week'  => '週2日',
+        'part_time'    => 'パートタイム',
+    ],
+];

--- a/src/resources/views/engineers/detail.blade.php
+++ b/src/resources/views/engineers/detail.blade.php
@@ -1,0 +1,218 @@
+@extends('layouts.app')
+
+@section('title', $engineer->name . 'さんの詳細情報')
+
+@section('content')
+<div class="container mt-4">
+    <div class="card mb-4">
+        <div class="card-header">
+            <div class="d-flex justify-content-between align-items-center">
+                <h4 class="mb-0">{{ $engineer->name }}さんの詳細情報</h4>
+                <a href="{{ url()->previous(route('engineers.show')) }}" class="btn btn-outline-secondary btn-sm">一覧へ戻る</a>
+            </div>
+        </div>
+        <div class="card-body">
+            {{-- 基本情報セクション --}}
+            <div class="mb-4">
+                <h5><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" fill="currentColor" class="bi bi-person-lines-fill me-2" viewBox="0 0 16 16"><path d="M6 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6m-5 6s-1 0-1-1 1-4 6-4 6 3 6 4-1 1-1 1zM11 3.5a.5.5 0 0 1 .5-.5h4a.5.5 0 0 1 0 1h-4a.5.5 0 0 1-.5-.5m.5 2.5a.5.5 0 0 0 0 1h4a.5.5 0 0 0 0-1zm0 2.5a.5.5 0 0 0 0 1h4a.5.5 0 0 0 0-1zm0 2.5a.5.5 0 0 0 0 1h4a.5.5 0 0 0 0-1z"/></svg>基本情報</h5>
+                <table class="table table-bordered">
+                    <tbody>
+                        <tr>
+                            <th style="width: 25%;">エンジニアID</th>
+                            <td>{{ $engineer->id }}</td>
+                        </tr>
+                        <tr>
+                            <th>氏名</th>
+                            <td>{{ $engineer->name }}</td>
+                        </tr>
+                        <tr>
+                            <th>年代</th>
+                            <td>{{ $engineer->age_group ?? '未設定' }}</td>
+                        </tr>
+                        <tr>
+                            <th>性別</th>
+                            <td>{{ $engineer->gender ?? '未設定' }}</td>
+                        </tr>
+                        <tr>
+                            <th>総実務経験年数</th>
+                            <td>{{ $engineer->total_experience_years ?? 'N/A' }} 年</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+
+            {{-- 稼働条件・希望セクション --}}
+            <div class="mb-4">
+                <h5><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" fill="currentColor" class="bi bi-calendar-check me-2" viewBox="0 0 16 16"><path d="M10.854 7.146a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708 0l-1.5-1.5a.5.5 0 1 1 .708-.708L7.5 9.793l2.646-2.647a.5.5 0 0 1 .708 0"/><path d="M3.5 0a.5.5 0 0 1 .5.5V1h8V.5a.5.5 0 0 1 1 0V1h1a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V3a2 2 0 0 1 2-2h1V.5a.5.5 0 0 1 .5-.5M1 4v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V4z"/></svg>稼働条件・希望</h5>
+                <table class="table table-bordered">
+                    <tbody>
+                        <tr>
+                            <th style="width: 25%;">希望単価</th>
+                            <td>
+                                @if(isset($engineer->desired_salary_min) && isset($engineer->desired_salary_max))
+                                    {{ number_format($engineer->desired_salary_min) }} 円 〜 {{ number_format($engineer->desired_salary_max) }} 円
+                                @elseif(isset($engineer->desired_salary_min))
+                                    {{ number_format($engineer->desired_salary_min) }} 円 〜
+                                @elseif(isset($engineer->desired_salary_max))
+                                    〜 {{ number_format($engineer->desired_salary_max) }} 円
+                                @else
+                                    未設定
+                                @endif
+                                ({{ $engineer->salary_type ?? 'N/A' }})
+                            </td>
+                        </tr>
+                        <tr>
+                            <th>稼働開始可能時期</th>
+                            <td>{{ $engineer->availability_start_date ? \Carbon\Carbon::parse($engineer->availability_start_date)->format('Y年m月d日') : '未設定' }}</td>
+                        </tr>
+                        <tr>
+                            <th>希望勤務地</th>
+                            <td>{{ $engineer->desired_work_location ?? '未設定' }}</td>
+                        </tr>
+                        <tr>
+                            <th>稼働率</th>
+                            <td>{{ $engineer->work_commitment_rate ?? '未設定' }}</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+
+            {{-- 自己PR・強み・推薦コメントセクション --}}
+            <div class="mb-4">
+                <h5><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" fill="currentColor" class="bi bi-chat-left-text-fill me-2" viewBox="0 0 16 16"><path d="M0 2a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H4.414a1 1 0 0 0-.707.293L.854 15.146A.5.5 0 0 1 0 14.793zm3.5 1a.5.5 0 0 0 0 1h9a.5.5 0 0 0 0-1zm0 2.5a.5.5 0 0 0 0 1h9a.5.5 0 0 0 0-1zm0 2.5a.5.5 0 0 0 0 1h5a.5.5 0 0 0 0-1z"/></svg>自己PR・強み・推薦</h5>
+                @if($engineer->self_pr)
+                    <div class="mb-2">
+                        <strong>自己PR/強み:</strong>
+                        <p style="white-space: pre-line;">{{ $engineer->self_pr }}</p>
+                    </div>
+                @endif
+                @if($engineer->agent_recommendation)
+                    <div class="mb-2">
+                        <strong>派遣事業者からの推薦コメント:</strong>
+                        <p style="white-space: pre-line;">{{ $engineer->agent_recommendation }}</p>
+                    </div>
+                @endif
+                @if($engineer->portfolio_url)
+                    <div class="mb-2">
+                        <strong>ポートフォリオ/実績公開URL:</strong>
+                        <p><a href="{{ $engineer->portfolio_url }}" target="_blank" rel="noopener noreferrer">{{ $engineer->portfolio_url }}</a></p>
+                    </div>
+                @endif
+                @if(!$engineer->self_pr && !$engineer->agent_recommendation && !$engineer->portfolio_url)
+                    <p>情報がありません。</p>
+                @endif
+            </div>
+
+            {{-- 保有スキルセクション --}}
+            @if($engineer->skills->isNotEmpty())
+            <div class="mb-4">
+                <h5><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" fill="currentColor" class="bi bi-tools me-2" viewBox="0 0 16 16"><path d="M1 0 0 1l2.2 3.081a1 1 0 0 0 .815.419h.07a1 1 0 0 1 .708.293l2.675 2.675-2.617 2.654A3.1 3.1 0 0 0 0 13a3 3 0 1 0 5.878-.851l2.654-2.617.968.968-.305.914a1 1 0 0 0 .242 1.023l3.356 3.356a1 1 0 0 0 1.414 0l1.586-1.586a1 1 0 0 0 0-1.414l-3.356-3.356a1 1 0 0 0-1.023-.242L10.5 9.5l-.96-.96A3.1 3.1 0 0 0 9 3.5a3 3 0 1 0-5.878.851L.851 1.149ZM15 1.5a.5.5 0 0 1 .5.5v3a.5.5 0 0 1-1 0v-3a.5.5 0 0 1 .5-.5M14.293.293a1 1 0 0 1 1.414 0l.001.001L16 1l-.207.207a1 1 0 0 1-1.414 0l-1.586-1.586a1 1 0 0 1 0-1.414l.207-.207L14.293.293Z"/></svg>保有スキル</h5>
+                <table class="table table-sm table-striped">
+                    <thead>
+                        <tr>
+                            <th>スキル名</th>
+                            <th>種別</th>
+                            <th>経験年数</th>
+                            <th>習熟度</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach($engineer->skills as $skill)
+                        <tr>
+                            <td>{{ $skill->name }}</td>
+                            <td>{{ ucfirst(str_replace('_', ' ', $skill->type)) }}</td>
+                            <td>{{ $skill->pivot->experience_years ?? 'N/A' }} 年</td>
+                            <td>{{ $skill->pivot->proficiency_level ?? 'N/A' }}</td>
+                        </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+            @endif
+
+            {{-- 職務経歴セクション --}}
+            @if($engineer->projectExperiences->isNotEmpty())
+            <div class="mb-4">
+                <h5><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" fill="currentColor" class="bi bi-briefcase-fill me-2" viewBox="0 0 16 16"><path d="M6.5 1A1.5 1.5 0 0 0 5 2.5V3H1.5A1.5 1.5 0 0 0 0 4.5v1.384l7.614 2.03a1.5 1.5 0 0 0 .772 0L16 5.884V4.5A1.5 1.5 0 0 0 14.5 3H11v-.5A1.5 1.5 0 0 0 9.5 1zM0 8v4.5A1.5 1.5 0 0 0 1.5 14h13a1.5 1.5 0 0 0 1.5-1.5V8l-7.528 2.259a.5.5 0 0 1-.444 0z"/></svg>職務経歴</h5>
+                @foreach($engineer->projectExperiences as $index => $experience)
+                <div class="card mb-3">
+                    <div class="card-header">
+                        プロジェクト {{ $index + 1 }}: {{ $experience->project_name ?? 'N/A' }}
+                    </div>
+                    <div class="card-body">
+                        <dl class="row">
+                            <dt class="col-sm-3">期間</dt>
+                            <dd class="col-sm-9">
+                                {{ $experience->start_date ? \Carbon\Carbon::parse($experience->start_date)->format('Y年m月') : 'N/A' }}
+                                〜
+                                {{ $experience->end_date ? \Carbon\Carbon::parse($experience->end_date)->format('Y年m月') : '現在' }}
+                            </dd>
+                            <dt class="col-sm-3">業界</dt>
+                            <dd class="col-sm-9">{{ $experience->industry ?? 'N/A' }}</dd>
+                            <dt class="col-sm-3">役割</dt>
+                            <dd class="col-sm-9">{{ $experience->roles ?? 'N/A' }}</dd>
+                            <dt class="col-sm-3">担当フェーズ</dt>
+                            <dd class="col-sm-9">{{ $experience->phases ?? 'N/A' }}</dd>
+                            <dt class="col-sm-3">概要</dt>
+                            <dd class="col-sm-9" style="white-space: pre-line;">{{ $experience->project_summary ?? 'N/A' }}</dd>
+                            <dt class="col-sm-3">使用ツール・技術</dt>
+                            <dd class="col-sm-9" style="white-space: pre-line;">{{ $experience->tools_technologies_used ?? 'N/A' }}</dd>
+                        </dl>
+                    </div>
+                </div>
+                @endforeach
+            </div>
+            @endif
+
+            {{-- 保有資格セクション --}}
+            @if($engineer->qualifications->isNotEmpty())
+            <div class="mb-4">
+                <h5><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" fill="currentColor" class="bi bi-patch-check-fill me-2" viewBox="0 0 16 16"><path d="M10.067.87a2.89 2.89 0 0 0-4.134 0l-.622.638-.89-.011a2.89 2.89 0 0 0-2.924 2.924l.01.89-.636.622a2.89 2.89 0 0 0 0 4.134l.637.622-.011.89a2.89 2.89 0 0 0 2.924 2.924l.89.01-.622.636a2.89 2.89 0 0 0 4.134 0l.622-.637.89.011a2.89 2.89 0 0 0 2.924-2.924l-.01-.89.636-.622a2.89 2.89 0 0 0 0-4.134l-.637-.622.011-.89a2.89 2.89 0 0 0-2.924-2.924l-.89-.01zm.287 5.984-3 3a.5.5 0 0 1-.708 0l-1.5-1.5a.5.5 0 1 1 .708-.708L7 8.793l2.646-2.647a.5.5 0 0 1 .708.708"/></svg>保有資格</h5>
+                <table class="table table-sm table-striped">
+                    <thead>
+                        <tr>
+                            <th>資格名</th>
+                            <th>取得日</th>
+                            <th>受験回数</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach($engineer->qualifications as $qualification)
+                        <tr>
+                            <td>{{ $qualification->name }}</td>
+                            <td>{{ $qualification->pivot->acquisition_date ? \Carbon\Carbon::parse($qualification->pivot->acquisition_date)->format('Y年m月d日') : 'N/A' }}</td>
+                            <td>{{ $qualification->pivot->attempts ?? 'N/A' }} 回</td>
+                        </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+            @endif
+
+            {{-- 外国語スキルセクション --}}
+            @if($engineer->languageSkills->isNotEmpty())
+            <div class="mb-4">
+                <h5><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" fill="currentColor" class="bi bi-translate me-2" viewBox="0 0 16 16"><path d="M4.545 6.714 4.11 8H3l1.862-5h1.284L8 8H6.833l-.435-1.286zm1.634-2.335L5.07 7.232h1.22L7.35 4.379zM10.088 5h-1.2V4h1.2zm-1.2 2h1.2V6h-1.2zm.32-5a.5.5 0 0 0-.5.5v1.5a.5.5 0 0 0 1 0V2.5a.5.5 0 0 0-.5-.5m-2.75 5h-1.2V4h1.2zm-1.2 2h1.2V6h-1.2zm.32-5a.5.5 0 0 0-.5.5v1.5a.5.5 0 0 0 1 0V2.5a.5.5 0 0 0-.5-.5M16 3.5a.5.5 0 0 1-.5.5H14a.5.5 0 0 1 0-1h1.5a.5.5 0 0 1 .5.5M13 10H3V9h10zm0-1H3V8h10zm0-1H3V7h10zm.5-2a.5.5 0 0 0-.5-.5h-13a.5.5 0 0 0 0 1h13a.5.5 0 0 0 .5-.5M2 5h12V4H2zm0 8h12V9H2zm1 0h10V8H3zm1-1h8V7H4zm1-1h6V6H5zm1-1h4V5H6z"/></svg>外国語スキル</h5>
+                <table class="table table-sm table-striped">
+                    <thead>
+                        <tr>
+                            <th>言語名</th>
+                            <th>習熟度</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach($engineer->languageSkills as $langSkill)
+                        <tr>
+                            <td>{{ $langSkill->language_name }}</td>
+                            <td>{{ $langSkill->proficiency_level }}</td>
+                        </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+            @endif
+
+        </div>
+    </div>
+</div>
+@endsection

--- a/src/resources/views/engineers/detail.blade.php
+++ b/src/resources/views/engineers/detail.blade.php
@@ -27,11 +27,11 @@
                         </tr>
                         <tr>
                             <th>年代</th>
-                            <td>{{ $engineer->age_group ?? '未設定' }}</td>
+                            <td>{{ $engineer->display_age_group }}</td>
                         </tr>
                         <tr>
                             <th>性別</th>
-                            <td>{{ $engineer->gender ?? '未設定' }}</td>
+                            <td>{{ $engineer->display_gender }}</td>
                         </tr>
                         <tr>
                             <th>総実務経験年数</th>
@@ -58,7 +58,7 @@
                                 @else
                                     未設定
                                 @endif
-                                ({{ $engineer->salary_type ?? 'N/A' }})
+                                ({{ $engineer->display_salary_type }})
                             </td>
                         </tr>
                         <tr>
@@ -71,7 +71,7 @@
                         </tr>
                         <tr>
                             <th>稼働率</th>
-                            <td>{{ $engineer->work_commitment_rate ?? '未設定' }}</td>
+                            <td>{{ $engineer->display_work_commitment_rate }}</td>
                         </tr>
                     </tbody>
                 </table>

--- a/src/resources/views/engineers/search_results.blade.php
+++ b/src/resources/views/engineers/search_results.blade.php
@@ -68,7 +68,11 @@
                                 <tbody>
                                     @foreach($engineers as $engineer)
                                     <tr>
-                                        <td>{{ $engineer->name }}</td>
+                                        <td>
+                                            <a href="{{ route('engineers.detail', ['engineer' => $engineer->id]) }}">
+                                            {{ $engineer->name }}
+                                            </a>
+                                        </td>
                                         <td>
                                             @foreach($engineer->skills->take(3) as $skill)
                                                 <span class="badge bg-info text-dark me-1">{{ $skill->name }} ({{ $skill->pivot->experience_years ?? 'N/A' }}年)</span>

--- a/src/resources/views/engineers/search_results.blade.php
+++ b/src/resources/views/engineers/search_results.blade.php
@@ -80,7 +80,7 @@
                                         <td>{{ $engineer->total_experience_years ?? 'N/A' }} 年</td>
                                         <td>{{ $engineer->desired_salary_min ? number_format($engineer->desired_salary_min) . ' 円' : 'N/A' }}</td>
                                         <td>{{ $engineer->availability_start_date ? \Carbon\Carbon::parse($engineer->availability_start_date)->format('Y年m月d日') : 'N/A' }}</td>
-                                        <td>{{ Str::limit($engineer->self_pr, 50) }}</td>
+                                        <td>{{ $engineer->self_pr}}</td>
                                     </tr>
                                     @endforeach
                                 </tbody>

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -18,5 +18,8 @@ Route::get('/hello', function () {
 // エンジニア検索フォーム表示
 Route::get('/engineers/search', [EngineerSearchController::class, 'showSearchForm'])->name('engineers.searchForm');
 
-// エンジニア検索実行と結果表示
+// エンジニア検索結果表示
 Route::get('/engineers/show', [EngineerSearchController::class, 'searchEngineers'])->name('engineers.show');
+
+// エンジニア詳細表示
+Route::get('/engineers/detail/{engineer}', [EngineerSearchController::class, 'showDetail'])->name('engineers.detail');


### PR DESCRIPTION
# エンジニア詳細画面の実装と検索結果画面の改善

## 概要 (Overview)

エンジニアの個別詳細情報を確認できる画面を新規に実装しました。
また、既存のエンジニア検索結果画面において、詳細画面への導線の追加および自己PR表示の改善を行いました。

## 対応内容 (Key Changes)

-   **エンジニア詳細画面の追加**
    -   エンジニアIDを元に、個別のエンジニア情報を表示する画面 (`/engineers/detail/{engineer}`) を新規に作成しました。
        -   ルート (`web.php`)、コントローラーメソッド (`EngineerSearchController@showDetail`)、Bladeビュー (`engineers.detail.blade.php`) を追加。
    -   表示項目として、エンジニアの基本情報、稼働条件・希望、自己PR・推薦コメント、ポートフォリオURLに加え、関連する全ての情報（保有スキル、職務経歴、保有資格、外国語スキル）を網羅的に表示するようにしました。
    -   以下のデータベースの値を、画面表示用に分かりやすい文言へ変換する処理（モデルアクセサおよび `config/display_mappings.php` を使用）を実装しました。
        -   年代 (`age_group`: 例 `30s_late` → `30代後半`)
        -   性別 (`gender`: 例 `male` → `男性`)
        -   単価タイプ (`salary_type`: 例 `monthly` → `月収`)
        -   稼働率 (`work_commitment_rate`: 例 `full_time` → `フルタイム`)

-   **エンジニア検索結果画面の改修 (`search_results.blade.php`)**
    -   エンジニア一覧テーブルの「氏名」欄に、各エンジニアの詳細画面へ遷移するためのリンクを追加しました。
    -   「自己PR (一部)」の表示を、省略せずに全文が表示されるように修正しました。

## 確認手順 (Verification Steps)

-   エンジニア検索結果一覧画面にて、各エンジニアの氏名が詳細画面へのリンクになっていることを確認しました。
-   氏名リンクをクリックすると、正しいエンジニアIDに対応する詳細画面 (`/engineers/detail/{id}`) へ遷移することを確認しました。
-   エンジニア詳細画面において、以下の情報がデータベースの内容に基づき正しく表示されることを確認しました。
    -   基本情報（ID, 氏名, 年代, 性別, 総実務経験年数）
    -   稼働条件・希望（希望単価・タイプ, 稼働開始時期, 希望勤務地, 稼働率）
    -   自己PR/強み、派遣事業者からの推薦コメント、ポートフォリオURL
    -   保有スキル（スキル名, 種別, 経験年数, 習熟度）
    -   職務経歴（プロジェクト名, 期間, 業界, 役割, 担当フェーズ, 概要, 使用ツール・技術）
    -   保有資格（資格名, 取得日, 受験回数）
    -   外国語スキル（言語名, 習熟度）
-   詳細画面で、年代、性別、単価タイプ、稼働率の各項目が、定義ファイル (`config/display_mappings.php`) に基づいた画面表示用の文言（例: 「30代後半」、「男性」、「月収」、「フルタイム」）に正しく変換されて表示されることを確認しました。
-   データが存在しない関連情報（スキル、職務経歴など）については、該当セクションが適切に「情報がありません」と表示されるか、またはセクション自体が非表示になるなど、適切に処理されていることを確認しました。
-   エンジニア検索結果画面の一覧で、自己PRが省略されずに全文表示されるようになっていることを確認しました。
-   詳細画面の「戻る」ボタンが、直前の検索結果一覧ページなど、適切なページへ遷移することを確認しました。

## その他 (Remarks)

-   エンジニア詳細画面のUIは、Bootstrapを使用した基本的な表示となっています。さらなるデザインやレイアウトの調整は今後の課題とします。
